### PR TITLE
Prepare for numpy 2

### DIFF
--- a/pyfvvdp/fvvdp.py
+++ b/pyfvvdp/fvvdp.py
@@ -1,6 +1,6 @@
 from abc import abstractmethod
 from urllib.parse import ParseResultBytes
-from numpy.lib.shape_base import expand_dims
+from numpy import expand_dims
 import torch
 from torch.utils import checkpoint
 from torch.functional import Tensor


### PR DESCRIPTION
To support `numpy>=2`, this line

https://github.com/gfxdisp/FovVideoVDP/blob/dd8e15cd125df51da6b925f8541669f6b40f1404/pyfvvdp/fvvdp.py#L3


should be changed to

```python
from numpy import expand_dims
```